### PR TITLE
Updated table styling

### DIFF
--- a/src/pages/table/table.py
+++ b/src/pages/table/table.py
@@ -2,6 +2,9 @@
 from dash import dash_table, html
 import dash_bootstrap_components as dbc
 
+# local imports
+from utils import color
+
 # set constants
 path = '/table'
 title = 'Table'
@@ -11,8 +14,25 @@ layout = dbc.Container(
     [
         html.H1('Table'),
         dash_table.DataTable(
-            id=table_id
-            # TODO: style table in css (make sure it doesn't go beyond 100% width)
+            id=table_id,
+            page_size=50,
+            sort_action='native',
+            filter_action='native',
+            style_data_conditional=[
+                {
+                    'if': {'row_index': 'odd'},
+                    'backgroundColor': color.light_grey
+                }
+            ],
+            style_header={
+                'backgroundColor': color.dark_grey
+            },
+            style_table={'overflowX': 'auto'},
+            style_cell={
+                'maxWidth': '180px',
+                'overflow': 'hidden',
+                'textOverflow': 'ellipsis'
+            }
         )
     ]
 )

--- a/src/utils/color.py
+++ b/src/utils/color.py
@@ -1,0 +1,2 @@
+light_grey = '#f6f6f6'
+dark_grey = '#e9e9e9'


### PR DESCRIPTION
Resolves #7 

Current table styling updates. I'm not sure how we want to handle long items that overflow. We can have them add height to the cell, but if the string goes beyond the maxWidth, it will overflow into the next column. This primarily happens with links (which aren't our main focus).

I think that this could be merged in now and we open a bug for future handling of links. 

Normally I wouldn't suggest that, but our primary use cases likely don't involve long text columns. 